### PR TITLE
Add image test and improve chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# naver-3b
+# HyperCLOVAX Chatbot Example
+
+This repository demonstrates a minimal chatbot built with
+[naver-hyperclovax/HyperCLOVAX-SEED-Vision-Instruct-3B].
+The bot supports text and image inputs and includes a simple GUI.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+- **CLI**
+
+```bash
+python main.py --image path/to/image.jpg
+```
+Type messages and enter `quit` to exit.
+
+- **GUI**
+
+```bash
+python main.py --gui
+```
+
+The window resembles a WhatsApp chat with the title **"충무병원 전용 챗봇"**.
+Use the **Attach Image** button to send an image.
+
+The model loads fully in `float32` precision to support the anyres projector
+as noted in the official discussions.
+
+## Tests
+
+Run the unit tests with:
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+Tests include a check that `generate_reply` accepts an image path and calls the
+processor and model correctly.
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,112 @@
+import argparse
+
+MODEL_NAME = "naver-hyperclovax/HyperCLOVAX-SEED-Vision-Instruct-3B"
+
+
+def load_model():
+    """Load tokenizer, processor and model in float32."""
+    import torch
+    from transformers import (
+        AutoModelForCausalLM,
+        AutoTokenizer,
+        AutoProcessor,
+    )
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+    processor = AutoProcessor.from_pretrained(MODEL_NAME)
+    model = AutoModelForCausalLM.from_pretrained(
+        MODEL_NAME,
+        torch_dtype=torch.float32,
+        device_map="cpu",
+    )
+    model.eval()
+    return tokenizer, processor, model
+
+
+def generate_reply(tokenizer, processor, model, text, image_path=None):
+    """Generate a reply optionally conditioned on an image."""
+    from PIL import Image
+    import torch
+
+    image = Image.open(image_path).convert("RGB") if image_path else None
+    inputs = processor(text=[text], images=[image] if image else None, return_tensors="pt")
+    with torch.no_grad():
+        outputs = model.generate(**inputs)
+    reply = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    return reply
+
+
+def chat_cli(args):
+    tokenizer, processor, model = load_model()
+    image_path = args.image
+    while True:
+        user = input("User: ")
+        if user.strip().lower() == "quit":
+            break
+        reply = generate_reply(tokenizer, processor, model, user, image_path)
+        print("Bot:", reply)
+        image_path = None
+
+
+def build_parser():
+    """Return CLI argument parser."""
+    parser = argparse.ArgumentParser(description="HyperCLOVAX Chatbot")
+    parser.add_argument("--image", help="optional image path", default=None)
+    parser.add_argument("--gui", action="store_true", help="launch GUI")
+    return parser
+
+
+def run_gui():
+    import tkinter as tk
+    from tkinter import filedialog, scrolledtext
+
+    tokenizer, processor, model = load_model()
+    window = tk.Tk()
+    window.title("충무병원 전용 챗봇")
+
+    chat_log = scrolledtext.ScrolledText(window, width=50, height=20)
+    chat_log.pack()
+
+    entry = tk.Entry(window, width=40)
+    entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
+
+    selected_image = {"path": None}
+
+    def send():
+        text = entry.get()
+        if not text:
+            return
+        reply = generate_reply(tokenizer, processor, model, text, selected_image["path"])
+        chat_log.insert(tk.END, f"You: {text}\n")
+        if selected_image["path"]:
+            chat_log.insert(tk.END, f"[Image: {selected_image['path']}]\n")
+        chat_log.insert(tk.END, f"Bot: {reply}\n")
+        entry.delete(0, tk.END)
+        selected_image["path"] = None
+
+    def attach_image():
+        path = filedialog.askopenfilename(title="Select image")
+        if path:
+            selected_image["path"] = path
+            chat_log.insert(tk.END, f"[Attached {path}]\n")
+
+    send_btn = tk.Button(window, text="Send", command=send)
+    send_btn.pack(side=tk.RIGHT)
+
+    attach_btn = tk.Button(window, text="Attach Image", command=attach_image)
+    attach_btn.pack(side=tk.RIGHT)
+
+    window.mainloop()
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.gui:
+        run_gui()
+    else:
+        chat_cli(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/project_file.md
+++ b/project_file.md
@@ -1,0 +1,19 @@
+# Project Plan
+
+This document tracks development of the HyperCLOVAX chatbot example.
+
+## 1. Setup Repository
+- Add minimal `requirements.txt`.
+- Create CLI and GUI in `main.py`.
+- Ensure model loads in `float32`.
+
+
+## 2. Added Features
+- Implemented CLI conversation with optional image input.
+- Implemented Tkinter GUI resembling WhatsApp style.
+- Added basic unit test for CLI parser.
+- Wrote README with usage instructions.
+
+## 3. Improvements
+- Added CPU float32 loading and torch.no_grad wrapper.
+- Added unit test verifying image handling in `generate_reply`.

--- a/project_plan.md
+++ b/project_plan.md
@@ -1,0 +1,19 @@
+# Project Plan
+
+This document tracks development of the HyperCLOVAX chatbot example.
+
+## 1. Setup Repository
+- Add minimal `requirements.txt`.
+- Create CLI and GUI in `main.py`.
+- Ensure model loads in `float32`.
+
+
+## 2. Added Features
+- Implemented CLI conversation with optional image input.
+- Implemented Tkinter GUI resembling WhatsApp style.
+- Added basic unit test for CLI parser.
+- Wrote README with usage instructions.
+
+## 3. Improvements
+- Added CPU float32 loading and torch.no_grad wrapper.
+- Added unit test verifying image handling in `generate_reply`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+transformers
+torch
+Pillow

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,12 @@
+import unittest
+from main import build_parser
+
+class ParserTest(unittest.TestCase):
+    def test_defaults(self):
+        parser = build_parser()
+        args = parser.parse_args([])
+        self.assertIsNone(args.image)
+        self.assertFalse(args.gui)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,34 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+try:
+    from PIL import Image
+    PIL_AVAILABLE = True
+except Exception:
+    PIL_AVAILABLE = False
+
+from main import generate_reply
+
+class GenerateReplyImageTest(unittest.TestCase):
+    @unittest.skipUnless(PIL_AVAILABLE, "Pillow not installed")
+    def test_generate_with_image(self):
+        tokenizer = MagicMock()
+        processor = MagicMock()
+        model = MagicMock()
+        tokenizer.decode.return_value = "ok"
+        processor.return_value = {"pixel_values": "dummy"}
+        model.generate.return_value = [[1]]
+
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            Image.new("RGB", (1, 1)).save(tmp.name)
+        try:
+            reply = generate_reply(tokenizer, processor, model, "hi", tmp.name)
+            self.assertEqual(reply, "ok")
+            processor.assert_called()
+            model.generate.assert_called()
+        finally:
+            os.unlink(tmp.name)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- refine model loader with explicit float32 CPU load
- use `torch.no_grad` in `generate_reply`
- add parser docstring and image unit test
- document float32 requirement and tests in README
- note progress in project plan files

## Testing
- `python -m unittest discover -s tests -v`
