### PR TITLE
Ensure CPU model loading and no-grad generation

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,9 +24,7 @@ def load_model():
     model = AutoModelForCausalLM.from_pretrained(
         MODEL_NAME,
         torch_dtype=torch.float32,
-
         device_map="cpu",
-
     )
     model.eval()
     return tokenizer, processor, model


### PR DESCRIPTION
## Summary
- ensure the model loader passes `device_map="cpu"`
- keep generation wrapped in a no-grad context

## Testing
- `python -m unittest discover -s tests -v`